### PR TITLE
Make symbols stay the same on client navigation

### DIFF
--- a/app/RandomSymbol.tsx
+++ b/app/RandomSymbol.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const symbols = ["⦂⦂", "⦿", "⊛", "⊚", "⊙", "⦚", "⟁", "⦂⦚"];
+
+function getRandomSymbol() {
+  const randomIndex = Math.floor(Math.random() * symbols.length);
+  return symbols[randomIndex];
+}
+
+export function RandomSymbol() {
+  const [symbol, setSymbol] = useState(" ");
+
+  useEffect(() => {
+    setSymbol(getRandomSymbol());
+  }, []);
+
+  return <>{symbol}</>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,7 @@
 import type { Metadata } from "next";
 import Link from 'next/link'
 import "./globals.css";
-
-//const symbols = ['⦂⦂', '⦿', '⊛', '⊚', '⊙', '⦚', '⟁', '⦂⦚'];
-const symbols = ['⦂⦚'];
-
-function getRandomSymbol() {
-  const randomIndex = Math.floor(Math.random() * symbols.length);
-  return symbols[randomIndex];
-}
+import { RandomSymbol } from "@/app/RandomSymbol";
 
 export const metadata: Metadata = {
   title: {
@@ -27,8 +20,8 @@ export default function RootLayout({
       <body className="dark:bg-black dark:text-white p-8 md:py-20">
         <div className="md:flex items-start gap-4">
           <Link href="/"
-            className="text-gold-500 text-6xl font-semibold hover:text-gold-400">
-            {getRandomSymbol()}
+            className="text-gold-500 text-6xl font-semibold hover:text-gold-400 w-14 text-right">
+            <RandomSymbol />
           </Link>
           <div>
             <header className="prose dark:prose-invert font-serif mb-10">


### PR DESCRIPTION
I tweeted but I haven't tweeted in a while so it may have been obliterated in your notifications. Thought I'd just open a quick PR with the fix you were after.

It basically moves the random symbol to a new client component, and uses `useEffect` to set the symbol once. Since `useEffect` doesn't run on the server or at build, it'll have a new random value each time the client is rendered, but stay persistent across client-side navigation.

End result is:
- Page renders on the server with no symbol
- Client loads and picks a random symbol
- Client side navigation keeps the same symbol
- On page refresh, a new symbol is rendered

See screen recording on [Twitter](https://twitter.com/samkingco/status/1750226881096417597)